### PR TITLE
Fix DYLIB path to libfreetype on macOS

### DIFF
--- a/freetype/ftimport.nim
+++ b/freetype/ftimport.nim
@@ -6,7 +6,7 @@
 #-----------------------------------------
 
 when defined(MACOSX):
-  const FT_LIB_NAME* = "libfreetype-6.dylib"
+  const FT_LIB_NAME* = "libfreetype(-6|.6|).dylib"
 elif defined(UNIX):
   const FT_LIB_NAME* = "libfreetype.so.6"
 else:


### PR DESCRIPTION
I use this library to render fonts with OpenGL on both NixOS and macOS Catalina, but on macOS I always got an error `could not load: libfreetype-6.dylib` (inside a nix shell and even outside of it). This name seems to be slightly off from the expected `libfreetype.6.dylib` which both `brew install freetype` as well as `nixpkgs.freetype` ship.

I added a commit that does not break compatibility with differently named libfreetype files though, and also allows for `libfreetype.dylib`.