### PR TITLE
Remove redundant when stmt

### DIFF
--- a/freetype/ftimport.nim
+++ b/freetype/ftimport.nim
@@ -12,9 +12,5 @@ elif defined(UNIX):
 else:
   const FT_LIB_NAME* = "libfreetype-6.dll"
 
-when defined(windows):
-  {.pragma: ftimport, cdecl, importc, dynlib: FT_LIB_NAME.}
-  {.pragma: ftcallback, cdecl.}
-else:
-  {.pragma: ftimport, cdecl, importc, dynlib: FT_LIB_NAME.}
-  {.pragma: ftcallback, cdecl.}
+{.pragma: ftimport, cdecl, importc, dynlib: FT_LIB_NAME.}
+{.pragma: ftcallback, cdecl.}


### PR DESCRIPTION
Unless I'm missing something, the two branches are *exactly* the same.