### PR TITLE
Fix required nim version

### DIFF
--- a/freetype.nimble
+++ b/freetype.nimble
@@ -9,4 +9,4 @@ installDirs   = @["freetype"]
 
 # Dependencies
 
-requires "nim >= 1.12.0"
+requires "nim >= 1.2.0"


### PR DESCRIPTION
Makes it so I don't have to have Nim 2.0 just to use the library. 

In all honesty, I don't know the *exact* required Nim version, but 1.2 or 1.4 seems good.