### PR TITLE
add emscripten support

### DIFF
--- a/freetype/ftimport.nim
+++ b/freetype/ftimport.nim
@@ -12,7 +12,10 @@ elif defined(UNIX):
 else:
   const FT_LIB_NAME* = "libfreetype-6.dll"
 
-when defined(freetypeStatic):
+when defined(emscripten):
+  {.passL: "-sUSE_FREETYPE=1".}
+  {.pragma: ftimport, cdecl, importc.}
+elif defined(freetypeStatic):
   when defined(vcc):
     {.link: "freetype.lib".}
   else:


### PR DESCRIPTION
https://github.com/treeform/nim_emscripten_tutorial

The `emscripten` flag is commonly used to mean "Compile using the emscripten backend" in Nim tutorials.

Compilation works properly and I'm rendering text in the browser using the change.